### PR TITLE
Remove usage of OS module in favor of pathlib

### DIFF
--- a/design.md
+++ b/design.md
@@ -40,3 +40,5 @@ A sound is added to the cache any time it is drawn from the database (or created
 
 Another advantage of our storage design is we can easily create mock objects.
 For example, our caching strategy does not make sense to use with a command line interface so we created a mock cache (`src/dummy_cache.py`) to be used with the cli (and also tests).
+
+All sounds are stored in a local directory.  We considered storing them in the database, but this would require storing them as binaries.  Note that we default to using `pathlib` for file operations over `os`.

--- a/src/audio_metadata.py
+++ b/src/audio_metadata.py
@@ -1,4 +1,4 @@
-from os.path import abspath
+from pathlib import Path
 import time
 import wave
 
@@ -9,7 +9,7 @@ class AudioMetadata:
     """
 
     def __init__(self, **kwargs):
-        self.file_path = abspath(kwargs["filePath"])
+        self.file_path = Path(kwargs["filePath"])
         self.name = kwargs["name"]
         self.duration = kwargs["duration"]
         self.date_added = kwargs["dateAdded"]
@@ -41,7 +41,7 @@ class AudioMetadata:
 
     def setDuration(self):
         # get the duration
-        with wave.open(self.file_path, "rb") as wave_read:
+        with wave.open(str(self.file_path), "rb") as wave_read:
             self.duration = int(wave_read.getnframes() / wave_read.getframerate())
 
     def updateLastAccessed(self):

--- a/src/commands.py
+++ b/src/commands.py
@@ -20,7 +20,7 @@ class Commander:
     def playAudio(self, name, reverse=False, volume=None, speed=None):
         audio = self.storage.getByName(name)
         file_path = audio.file_path
-        with wave.open(file_path, "rb") as wave_read:
+        with wave.open(str(file_path), "rb") as wave_read:
             audio_data = wave_read.readframes(wave_read.getnframes())
             num_channels = wave_read.getnchannels()
             bytes_per_sample = wave_read.getsampwidth()

--- a/src/storage_commander.py
+++ b/src/storage_commander.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from shutil import copyfile, move
 import time
@@ -54,8 +53,7 @@ class StorageCommander:
             return False
         self.database.removeByName(name)
         self.cache.removeByName(name)
-        if os.path.exists(audio.file_path):
-            os.remove(audio.file_path)
+        audio.file_path.unlink(missing_ok=True)  # remove file
         return True
 
     def getByName(self, name):
@@ -82,10 +80,10 @@ class StorageCommander:
         audio = self.getByName(old_name)
         if audio is None or self.getByName(new_name) is not None:
             return False
-        new_path = os.path.join(self.base_directory, f"{new_name}.wav")
+        new_path = Path(self.base_directory, f"{new_name}.wav")
         move(audio.file_path, new_path)
         audio.file_path = new_path
-        self.database.rename(old_name, new_name, new_path)
+        self.database.rename(old_name, new_name, str(new_path))
         self.cache.rename(old_name, new_name)
         return True
 
@@ -101,7 +99,7 @@ class StorageCommander:
         sounds = self.getAll()
         removed_sounds = []
         for sound in sounds:
-            if not os.path.exists(sound.file_path):
+            if not sound.file_path.exists():
                 self.removeSound(sound.name)
                 removed_sounds.append(sound)
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import shutil
 import unittest
@@ -11,78 +10,80 @@ from src.storage_commander import StorageCommander
 
 
 def addAllSounds(base_dir, commander):
-    for fname in os.listdir(base_dir):
-        commander.addSound(os.path.join(base_dir, fname))
+    for path in Path(base_dir).iterdir():
+        commander.addSound(path)
 
 
 class BasicTests(unittest.TestCase):
     # copy the test_sounds directory so that way we can modify it without worry
     def setUp(self):
-        self.base_dir = os.path.join("test", "temp_test_sounds")
-        shutil.copytree(os.path.join("test", "test_sounds"), self.base_dir)
-        self.db_name = os.path.join("test", "test_audio_archive.db")
-        create_db(self.db_name)
-        storage = StorageCommander(DummyCache(), Sqlite(self.db_name), self.base_dir)
+        self.base_dir = Path("test", "temp_test_sounds")
+        shutil.copytree(Path("test", "test_sounds"), self.base_dir)
+        self.db_name = Path("test", "test_audio_archive.db")
+        create_db(str(self.db_name))
+        storage = StorageCommander(
+            DummyCache(), Sqlite(str(self.db_name)), str(self.base_dir)
+        )
         self.commander = Commander(storage)
 
     def tearDown(self):
-        os.remove(self.db_name)
+        Path(self.db_name).unlink()
         shutil.rmtree(self.base_dir)
 
     def test_addSoundInDirSameName(self):
-        self.commander.addSound(os.path.join(self.base_dir, "coffee.wav"))
+        self.commander.addSound(Path(self.base_dir, "coffee.wav"))
         sound = self.commander.storage.getByName("coffee")
         # the new sound should be in the database
         self.assertEqual(sound.name, "coffee")
-        self.assertTrue(os.path.exists(sound.file_path))
+        self.assertTrue(sound.file_path.exists())
 
     def test_addSoundInDirNewName(self):
-        self.commander.addSound(os.path.join(self.base_dir, "coffee.wav"), "new_sound")
+        self.commander.addSound(Path(self.base_dir, "coffee.wav"), "new_sound")
         sound = self.commander.storage.getByName("new_sound")
         # the new sound should be in the database
         self.assertEqual(sound.name, "new_sound")
         # the file should be renamed
-        self.assertTrue(os.path.exists(os.path.join(self.base_dir, "new_sound.wav")))
+        self.assertTrue(Path(self.base_dir, "new_sound.wav").exists())
         # the old file should not be there
-        self.assertFalse(os.path.exists(os.path.join(self.base_dir, "coffee.wav")))
+        self.assertFalse(Path(self.base_dir, "coffee.wav").exists())
 
     def test_addSoundOtherDirSameName(self):
-        old_path = os.path.join("test_sound.wav")
-        shutil.move(os.path.join(self.base_dir, "coffee.wav"), old_path)
+        old_path = Path("test_sound.wav")
+        shutil.move(Path(self.base_dir, "coffee.wav"), old_path)
         self.commander.addSound(old_path)
         sound = self.commander.storage.getByName("test_sound")
         # the new sound should be in the database
         self.assertEqual(sound.name, "test_sound")
         # the file should be renamed
-        self.assertTrue(os.path.exists(os.path.join(self.base_dir, "test_sound.wav")))
+        self.assertTrue(Path(self.base_dir, old_path).exists())
         # the old file should be there too
-        self.assertTrue(os.path.exists(old_path))
-        os.remove(old_path)
+        self.assertTrue(old_path.exists())
+        old_path.unlink()
 
     def test_addSoundOtherDirNewName(self):
-        old_path = os.path.join("test_sound.wav")
-        shutil.move(os.path.join(self.base_dir, "coffee.wav"), old_path)
+        old_path = Path("test_sound.wav")
+        shutil.move(Path(self.base_dir, "coffee.wav"), old_path)
         self.commander.addSound(old_path, "new_sound")
         sound = self.commander.storage.getByName("new_sound")
         # the new sound should be in the database
         self.assertEqual(sound.name, "new_sound")
         # the file should be renamed
-        self.assertTrue(os.path.exists(os.path.join(self.base_dir, "new_sound.wav")))
+        self.assertTrue(Path(self.base_dir, "new_sound.wav").exists())
         # the old file should be there too
-        self.assertTrue(os.path.exists(old_path))
-        os.remove(old_path)
+        self.assertTrue(old_path.exists())
+        old_path.unlink()
 
     def test_addSoundAlreadyExists(self):
-        path = os.path.join(self.base_dir, "coffee.wav")
+        path = Path(self.base_dir, "coffee.wav")
         # we should be able to add this the first time but not the second
         self.assertTrue(self.commander.addSound(path))
         self.assertFalse(self.commander.addSound(path))
 
     def test_removeSoundSuccess(self):
-        path = os.path.join(self.base_dir, "coffee.wav")
+        path = Path(self.base_dir, "coffee.wav")
         self.commander.addSound(path)
         self.assertTrue(self.commander.removeSound("coffee"))
-        self.assertFalse(os.path.exists(path))
+        self.assertFalse(path.exists())
 
     def test_removeSoundFail(self):
         # can't remove a sound if it doesn't exist
@@ -109,8 +110,8 @@ class BasicTests(unittest.TestCase):
         sound = self.commander.storage.getByName("new_name")
         self.assertEqual(Path(sound.file_path).stem, "new_name")
         self.assertEqual(sound.name, "new_name")
-        self.assertTrue(os.path.exists(os.path.join(self.base_dir, "new_name.wav")))
-        self.assertFalse(os.path.exists(os.path.join(self.base_dir, "coffee.wav")))
+        self.assertTrue(Path(self.base_dir, "new_name.wav").exists())
+        self.assertFalse(Path(self.base_dir, "coffee.wav").exists())
 
     def test_renameBadOldName(self):
         addAllSounds(self.base_dir, self.commander)
@@ -142,8 +143,8 @@ class BasicTests(unittest.TestCase):
     def test_clean(self):
         addAllSounds(self.base_dir, self.commander)
         # remove coffee.wav and toaster.wav and make sure that clean removes them
-        os.remove(os.path.join(self.base_dir, "coffee.wav"))
-        os.remove(os.path.join(self.base_dir, "toaster.wav"))
+        Path(self.base_dir, "coffee.wav").unlink()
+        Path(self.base_dir, "toaster.wav").unlink()
         removed_sounds = {sound.name for sound in self.commander.clean()}
         self.assertSetEqual(removed_sounds, {"coffee", "toaster"})
 


### PR DESCRIPTION
We interchangeably used the `os` and `pathlib` modules, so I swapped everywhere we used `os` to use `pathlib` instead.  I went ahead and chose `pathlib` because it is more modern and I figured no one would care.