### PR TITLE
handle parallel and sequential play as audio effects rather than their own play functions.

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -171,11 +171,10 @@ class Cli:
                 end_sec=args.end_sec,
                 save=args.save,
                 transpose=args.transpose,
+                parallel=args.parallel,
             )
-            if args.parallel:
-                self.commander.playParallel(args.names, playback_options)
-            else:
-                self.commander.playSequence(args.names, playback_options)
+            commander.playAudio(args.names, playback_options)
+
         except ValueError as e:
             print(f"Error: {e}")
         except NameMissing as e:
@@ -183,7 +182,9 @@ class Cli:
         except FileNotFoundError as e:
             print(f"Error: {e}")
         except NameExists as e:
-            print(f"{args.save} already exists in the archive - edited version not saved.")
+            print(
+                f"{args.save} already exists in the archive - edited version not saved."
+            )
 
     def _handleList(self, args):
         # TODO: Consider a better way to handle filtering by tags.

--- a/src/playback_options.py
+++ b/src/playback_options.py
@@ -10,6 +10,7 @@ class PlaybackOptions:
         end_sec,
         save,
         transpose,
+        parallel,
     ):
         """Constructor.
 
@@ -19,6 +20,7 @@ class PlaybackOptions:
             reverse: bool
             start_percent/end_percent: float, 0 <= start_percent < end_percent < 1
             start_sec/end_sec: float >= 0
+            parallel: bool (if true, the sounds will be overlayed, else they will be concatenated)
 
         Raises:
             ValueError: invalid option.
@@ -56,3 +58,4 @@ class PlaybackOptions:
         self.end_sec = end_sec
         self.save = save
         self.transpose = transpose
+        self.parallel = parallel


### PR DESCRIPTION
This fixes #84 (and it's good to take that logic out of `commands.py`).